### PR TITLE
starlark: Disallow positional arguments after keyword arguments

### DIFF
--- a/starlark/parser.h
+++ b/starlark/parser.h
@@ -347,6 +347,7 @@ class Parser {
 
     std::optional<std::vector<Argument>> parse_argument_list() {
         std::vector<Argument> args;
+        bool seen_kw_arg = false;
 
         while (true) {
             auto maybe_token = next_token();
@@ -391,6 +392,7 @@ class Parser {
                 }
 
                 if (std::holds_alternative<token::Equals>(*next)) {
+                    seen_kw_arg = true;
                     name = Identifier{.name = std::move(ident->name)};
 
                     auto value_token = next_token();
@@ -412,6 +414,11 @@ class Parser {
 
                 // Not a named argument, fall through to regular arg handling.
                 reconsume(std::move(*next));
+            }
+
+            if (seen_kw_arg) {
+                std::cerr << "Positional argument may not follow keyword argument.\n";
+                return std::nullopt;
             }
 
             auto value_expr = parse_expression(token);

--- a/starlark/parser_test.cc
+++ b/starlark/parser_test.cc
@@ -65,7 +65,7 @@ int main() {
             },
         },
         {
-            R"(foo(bar = "baz", "qux"))",
+            R"(foo("qux", bar = "baz"))",
             starlark::Program{
                 .statements{
                     starlark::ExpressionStmt{
@@ -75,12 +75,12 @@ int main() {
                                     starlark::Identifier{"foo"}),
                                 .args{
                                     {
-                                        starlark::Identifier{"bar"},
-                                        starlark::StringLiteral{"baz"},
-                                    },
-                                    {
                                         std::nullopt,
                                         starlark::StringLiteral{"qux"},
+                                    },
+                                    {
+                                        starlark::Identifier{"bar"},
+                                        starlark::StringLiteral{"baz"},
                                     },
                                 },
                             },
@@ -90,7 +90,7 @@ int main() {
             },
         },
         {
-            R"(foo(bar = baz, qux()))",
+            R"(foo(qux(), bar = baz))",
             starlark::Program{
                 .statements{
                     starlark::ExpressionStmt{
@@ -100,16 +100,16 @@ int main() {
                                     starlark::Identifier{"foo"}),
                                 .args{
                                     {
-                                        starlark::Identifier{"bar"},
-                                        starlark::Identifier{"baz"},
-                                    },
-                                    {
                                         std::nullopt,
                                         starlark::CallExpr{
                                             .target = std::make_shared<starlark::Expression>(
                                                 starlark::Identifier{"qux"}),
                                             .args{},
                                         },
+                                    },
+                                    {
+                                        starlark::Identifier{"bar"},
+                                        starlark::Identifier{"baz"},
                                     },
                                 },
                             },
@@ -331,7 +331,9 @@ int main() {
     static constexpr auto kExpectedParseFailures = std::to_array<std::string_view>({
         // CallExpr
         // Missing closing parenthesis.
-        R"(foo(bar = "baz", "qux")",
+        R"(foo("qux")",
+        // Positional argument after kw argument.
+        R"(foo(bar = baz, qux()))",
 
         // ListExpr
         // Tokenization error.


### PR DESCRIPTION
This matches what Bazel does: `package contains errors: ffs: positional argument may not follow keyword argument`