### PR TITLE
build: Use a feature for treating warnings as errors

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,0 +1,7 @@
+"""Repository-level metadata."""
+
+repo(
+    features = [
+        "treat_warnings_as_errors",
+    ],
+)

--- a/bzl/copts.bzl
+++ b/bzl/copts.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2025 Robin Lindén <dev@robinlinden.eu>
+# SPDX-FileCopyrightText: 2022-2026 Robin Lindén <dev@robinlinden.eu>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -8,7 +8,6 @@ FFS_LINUX_WARNING_FLAGS = [
     "-Wall",
     "-Wextra",
     "-pedantic-errors",
-    "-Werror",
     "-fno-common",
     "-Wctad-maybe-unsupported",
     "-Wdouble-promotion",
@@ -28,14 +27,11 @@ FFS_LINUX_WARNING_FLAGS = [
 FFS_MSVC_WARNING_FLAGS = [
     # More warnings.
     "/W4",
-    # Treat warnings as errors.
-    "/WX",
 ]
 
 FFS_CLANG_CL_WARNING_FLAGS = [
     # -Wall in clang-cl is an alias of -Weverything, and -W4 is an alias of clang's -Wall + -Wextra.
     "-W4",
-    "-Werror",
     # Common idiom for zeroing members.
     "-Wno-missing-field-initializers",
 ]


### PR DESCRIPTION
This means we'll support disabling `-Werror` in this repo by passing `--features=-treat_warnings_as_errors`.