### PR TITLE
meta/clang-format: Don't indent access modifiers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,3 +9,4 @@ ColumnLimit: 100
 BreakTemplateDeclarations: Yes
 SpaceAfterTemplateKeyword: false
 QualifierAlignment: Right
+AccessModifierOffset: -4

--- a/starlark/interpreter.h
+++ b/starlark/interpreter.h
@@ -37,7 +37,7 @@ struct NativeArgument {
 
 // TODO(robinlinden): Error-handling.
 class Interpreter {
-  public:
+public:
     std::map<std::string, Value> variables;
 
     std::optional<Value> run(Program const &program) {

--- a/starlark/parser.h
+++ b/starlark/parser.h
@@ -20,7 +20,7 @@
 namespace starlark {
 
 class Parser {
-  public:
+public:
     explicit Parser(std::string_view input) : tokenizer_{input} {}
 
     std::optional<Program> parse() {
@@ -102,7 +102,7 @@ class Parser {
         return std::nullopt;
     }
 
-  private:
+private:
     Tokenizer tokenizer_;
     std::optional<Token> peeked_token_;
 

--- a/starlark/tokenizer.h
+++ b/starlark/tokenizer.h
@@ -23,7 +23,7 @@
 namespace starlark {
 
 class Tokenizer {
-  public:
+public:
     explicit Tokenizer(std::string_view input) : input_(input) {}
 
     std::optional<Token> tokenize() {
@@ -66,7 +66,7 @@ class Tokenizer {
         return tokenize_punctuator();
     }
 
-  private:
+private:
     bool is_whitespace(char c) const { return c == ' ' || c == '\t' || c == '\r'; }
 
     bool is_alpha(char c) const {


### PR DESCRIPTION
Having them half-indented is a bother, and this is what I'm used to.