### PR TITLE
build: Fix rules_cc passing a removed flag to MSVC

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,16 @@ module(name = "ffs")
 
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.18")
+single_version_override(
+    module_name = "rules_cc",
+    patch_cmds = [
+        # Fix rules_cc passing the deprecated and removed /DEBUG:FASTLINK flag to MSVC.
+        # https://github.com/bazelbuild/rules_cc/issues/558
+        """sed -i 's|/DEBUG:FASTLINK|/DEBUG:FULL|' cc/private/toolchain/windows_cc_configure.bzl""",
+    ],
+    version = "0.2.18",
+)
+
 bazel_dep(name = "rules_fuzzing", version = "0.6.0")
 bazel_dep(name = "hastur")
 archive_override(


### PR DESCRIPTION
Passing `/DEBUG:FASTLINK` to VS2026 emits a warning which is treated as
an error due to us building w/ `--features=treat_warnings_as_errors`.

    LINK : warning LNK4315: /DEBUG:FASTLINK is no longer supported.
    Using /DEBUG:FULL instead. Use a VS 2022 toolchain to continue
    building with /DEBUG:FASTLINK